### PR TITLE
Fixed up gulp build issue which resulted in app.js being excluded

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var paths = {
 	metadata: ['**/package.json', '!node_modules/**/package.json', '**/tsconfig.json', '**/jsconfig.json']
 }
 
-gulp.task('compile', function () {
+gulp.task('compile', ['stamp'], function () {
 	return gulp
 		.src(paths.typescript)
 		.pipe(ts(tsconfig.compilerOptions))
@@ -44,7 +44,7 @@ gulp.task('stamp', function (callback) {
 	});
 });
 
-gulp.task('pack', function (callback) {
+gulp.task('pack', ['compile'], function (callback) {
 	exec('npm pack', function (err, stdout, stderr) {
 		console.log(stdout);
 		console.log(stderr);
@@ -68,5 +68,5 @@ gulp.task('watch', ['default'], function () {
 	gulp.watch(paths.docs, ['docs']);
 });
 
-gulp.task('default', ['stamp', 'compile', 'pack', 'docs']);
-gulp.task('ci', ['stamp', 'compile', 'pack']);
+gulp.task('default', ['pack', 'docs']);
+gulp.task('ci', ['pack']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "namerer",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"description": "Namerer is a simple tool to generate names and check them for availability.",
 	"main": "app.js",
 	"scripts": {


### PR DESCRIPTION
The 1.0.0 version of the package had a fatal flaw that the `app.js` file simply wasn't there. This is a transient error that has been happening from package version to package version. The problem was that the `gulpfile.js` file didn't list the `pack` task as having a dependency on the `compile` task.

Previously I had both the `pack` and `compile` tasks as dependencies to the `default` and `ci` tasks, but this introduced the possibility of the `pack` task starting and completing before the `compile` task was completed, resulting it being excluded from the package.

Doh! Gulp fail - now I know better how this works - I think.
